### PR TITLE
Hide the game buffer from bufferline

### DIFF
--- a/lua/nvimesweeper/ui.lua
+++ b/lua/nvimesweeper/ui.lua
@@ -342,7 +342,7 @@ local function move_cursor_to_click()
 end
 
 function M.new_ui(game, open_tab)
-  local buf = api.nvim_create_buf(false, true)
+  local buf = api.nvim_create_buf(open_tab, true)
   if buf == 0 then
     error "failed to create game buffer!"
   end

--- a/lua/nvimesweeper/ui.lua
+++ b/lua/nvimesweeper/ui.lua
@@ -342,7 +342,7 @@ local function move_cursor_to_click()
 end
 
 function M.new_ui(game, open_tab)
-  local buf = api.nvim_create_buf(true, true)
+  local buf = api.nvim_create_buf(false, true)
   if buf == 0 then
     error "failed to create game buffer!"
   end


### PR DESCRIPTION
Currently if I launch the game in a float or tab, the game buffer is shown in bufferline, which is very annoying and distracting.

Tested with this change, the game seems to be working perfectly.